### PR TITLE
Fix duplicate audio on background playback

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ android {
         minSdkVersion 26
         targetSdkVersion 33
         versionCode 112
-        versionName "15.7.4-patch1"
+        versionName "15.7.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/com/kusamaru/standroid/MainActivity.kt
+++ b/app/src/main/java/com/kusamaru/standroid/MainActivity.kt
@@ -30,6 +30,8 @@ import com.kusamaru.standroid.nicovideo.NicoVideoSelectFragment
 import com.kusamaru.standroid.nicovideo.compose.JCNicoVideoCommentOnlyFragment
 import com.kusamaru.standroid.nicovideo.compose.JCNicoVideoFragment
 import com.kusamaru.standroid.nicovideo.fragment.NicoVideoCacheFragment
+import com.kusamaru.standroid.service.NicoVideoPlayService
+import com.kusamaru.standroid.service.NicoVideoPlayServiceHandoff
 import com.kusamaru.standroid.service.startLivePlayService
 import com.kusamaru.standroid.service.startVideoPlayService
 import com.kusamaru.standroid.setting.SettingsFragment
@@ -189,6 +191,59 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+    }
+
+    override fun onResume() {
+        super.onResume()
+        restoreBackgroundVideoPlayback()
+    }
+
+    private fun restoreBackgroundVideoPlayback() {
+        val handoffState = NicoVideoPlayServiceHandoff.state ?: return
+        NicoVideoPlayServiceHandoff.clear()
+        stopService(Intent(this, NicoVideoPlayService::class.java))
+
+        val currentFragment = supportFragmentManager.findFragmentById(R.id.main_activity_fragment_layout)
+        val restoredToExistingFragment = when (currentFragment) {
+            is NicoVideoFragment -> restoreNicoVideoFragmentPlayback(
+                currentVideoId = currentFragment.viewModel.playingVideoId.value,
+                handoffVideoId = handoffState.videoId,
+                positionMs = handoffState.positionMs,
+                seek = { currentFragment.viewModel.playerSetSeekMs.value = it },
+                play = { currentFragment.viewModel.playerIsPlaying.value = true }
+            )
+            is JCNicoVideoFragment -> restoreNicoVideoFragmentPlayback(
+                currentVideoId = currentFragment.viewModel.playingVideoId.value,
+                handoffVideoId = handoffState.videoId,
+                positionMs = handoffState.positionMs,
+                seek = { currentFragment.viewModel.playerSetSeekMs.value = it },
+                play = { currentFragment.viewModel.playerIsPlaying.value = true }
+            )
+            else -> false
+        }
+
+        if (!restoredToExistingFragment) {
+            val startPos = (handoffState.positionMs / 1000L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+            setNicovideoFragment(
+                videoId = handoffState.videoId,
+                isCache = handoffState.isCache,
+                _videoList = handoffState.playlist,
+                startPos = startPos
+            )
+        }
+    }
+
+    private fun restoreNicoVideoFragmentPlayback(
+        currentVideoId: String?,
+        handoffVideoId: String,
+        positionMs: Long,
+        seek: (Long) -> Unit,
+        play: () -> Unit
+    ): Boolean {
+        if (currentVideoId != handoffVideoId) return false
+        seek(positionMs)
+        play()
+        return true
     }
 
     /** クラッシュレポートを回収する */

--- a/app/src/main/java/com/kusamaru/standroid/MainActivity.kt
+++ b/app/src/main/java/com/kusamaru/standroid/MainActivity.kt
@@ -556,6 +556,9 @@ class MainActivity : AppCompatActivity() {
                 // 動画
                 is NicoVideoFragment -> {
                     viewModel.nicoVideoData.value?.apply {
+                        if (isLeaveAppPopup || isLeaveAppBackground) {
+                            viewModel.playerIsPlaying.value = false
+                        }
                         when {
                             isLeaveAppPopup -> startVideoPlayService(context = context, mode = "popup", videoId = videoId, isCache = isCache, videoQuality = viewModel.currentVideoQuality, audioQuality = viewModel.currentAudioQuality, seek = viewModel.currentPosition)
                             isLeaveAppBackground -> startVideoPlayService(context = context, mode = "background", videoId = videoId, isCache = isCache, videoQuality = viewModel.currentVideoQuality, audioQuality = viewModel.currentAudioQuality, seek = viewModel.currentPosition)
@@ -564,6 +567,9 @@ class MainActivity : AppCompatActivity() {
                 }
                 is JCNicoVideoFragment -> {
                     viewModel.nicoVideoData.value?.apply {
+                        if (isLeaveAppPopup || isLeaveAppBackground) {
+                            viewModel.playerIsPlaying.value = false
+                        }
                         when {
                             isLeaveAppPopup -> startVideoPlayService(context = context, mode = "popup", videoId = videoId, isCache = isCache, videoQuality = viewModel.currentVideoQuality, audioQuality = viewModel.currentAudioQuality, seek = viewModel.currentPosition)
                             isLeaveAppBackground -> startVideoPlayService(context = context, mode = "background", videoId = videoId, isCache = isCache, videoQuality = viewModel.currentVideoQuality, audioQuality = viewModel.currentAudioQuality, seek = viewModel.currentPosition)

--- a/app/src/main/java/com/kusamaru/standroid/service/NicoVideoPlayService.kt
+++ b/app/src/main/java/com/kusamaru/standroid/service/NicoVideoPlayService.kt
@@ -80,6 +80,9 @@ class NicoVideoPlayService : Service() {
     private lateinit var windowManager: WindowManager
     private lateinit var broadcastReceiver: BroadcastReceiver
     private lateinit var mediaSessionCompat: MediaSessionCompat
+    private var isBroadcastReceiverRegistered = false
+    private var isMediaSessionActive = false
+    private var playbackGeneration = 0
 
     // 再生するやつ
     private lateinit var exoPlayer: ExoPlayer
@@ -156,6 +159,9 @@ class NicoVideoPlayService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        playbackGeneration++
+        val generation = playbackGeneration
+        resetPlaybackStateForRestart()
         // 受け取り
         playMode = intent?.getStringExtra("mode") ?: "popup"
         val videoId = intent?.getStringExtra("video_id") ?: ""
@@ -166,6 +172,7 @@ class NicoVideoPlayService : Service() {
         startAudioQuality = intent?.getStringExtra("audio_quality")
 
         // 連続再生？
+        playlist.clear()
         if (intent?.getSerializableExtra("playlist") != null) {
             playlist.addAll(intent.getSerializableExtra("playlist") as ArrayList<NicoVideoData>)
         }
@@ -185,24 +192,56 @@ class NicoVideoPlayService : Service() {
             val playlistStartCanUseCache = playlist[currentPlaylistPos].isCache // キャッシュ再生が使えるか
             if (playlistStartCanUseCache) {
                 // キャッシュ再生
-                cachePlay(playlistStartId)
+                cachePlay(playlistStartId, generation)
             } else {
                 // データ取得など
-                coroutine(playlistStartId)
+                coroutine(playlistStartId, generation)
             }
         } else {
             // 通常
             if (isCache) {
                 // キャッシュ再生
-                cachePlay(videoId)
+                cachePlay(videoId, generation)
             } else {
                 // データ取得など
-                coroutine(videoId)
+                coroutine(videoId, generation)
             }
         }
 
         initBroadcast()
         return START_NOT_STICKY
+    }
+
+    /** Restart-safe cleanup before accepting a new playback intent. */
+    private fun resetPlaybackStateForRestart() {
+        if (::exoPlayer.isInitialized) {
+            exoPlayer.stop()
+            exoPlayer.clearMediaItems()
+            exoPlayer.release()
+        }
+        if (isMediaSessionActive) {
+            mediaSessionCompat.apply {
+                isActive = false
+                setPlaybackState(PlaybackStateCompat.Builder().setState(PlaybackStateCompat.STATE_NONE, 0L, 1F).build())
+                release()
+            }
+            isMediaSessionActive = false
+        }
+        if (viewBinding != null) {
+            windowManager.removeView(viewBinding!!.root)
+            viewBinding = null
+            commentCanvas = null
+        }
+        if (isBroadcastReceiverRegistered) {
+            unregisterReceiver(broadcastReceiver)
+            isBroadcastReceiverRegistered = false
+        }
+        seekTimer.cancel()
+        seekTimer = Timer()
+        rawVideoCommentList.clear()
+        currentVideoCommentList.clear()
+        drewedList.clear()
+        nicoVideoHTML.destroy()
     }
 
     /** ExoPlayerを用意する */
@@ -356,7 +395,7 @@ class NicoVideoPlayService : Service() {
      * インターネットから動画を取得して再生する
      * @param videoId 動画ID
      * */
-    private fun coroutine(videoId: String) {
+    private fun coroutine(videoId: String, generation: Int = playbackGeneration) {
         isCurrentVideoCache = false
         currentVideoId = videoId
 
@@ -433,7 +472,13 @@ class NicoVideoPlayService : Service() {
             }
             // タイトル
             currentVideoTitle = jsonObject.getJSONObject("video").getString("title")
+            if (generation != playbackGeneration) {
+                return@launch
+            }
             withContext(Dispatchers.Main) {
+                if (generation != playbackGeneration) {
+                    return@withContext
+                }
                 // ExoPlayer
                 playExoPlayer(false, contentUrl, nicoHistory, domandCookie)
                 if (isPopupPlay()) {
@@ -491,7 +536,7 @@ class NicoVideoPlayService : Service() {
      * キャッシュを利用して動画を再生
      * @param videoId 動画ID
      * */
-    private fun cachePlay(videoId: String) {
+    private fun cachePlay(videoId: String, generation: Int = playbackGeneration) {
         val nicoVideoCache = NicoVideoCache(this)
         isCurrentVideoCache = true
         currentVideoId = videoId
@@ -519,7 +564,13 @@ class NicoVideoPlayService : Service() {
                     // コメント取得
                     val commentJSON = nicoVideoCache.getCacheFolderVideoCommentText(videoId)
                     currentVideoCommentList = ArrayList(nicoVideoHTML.parseCommentJSON(commentJSON, videoId))
+                    if (generation != playbackGeneration) {
+                        return@launch
+                    }
                     withContext(Dispatchers.Main) {
+                        if (generation != playbackGeneration) {
+                            return@withContext
+                        }
                         // ExoPlayer
                         playExoPlayer(true, contentUrl, "", null)
                         if (isPopupPlay()) {
@@ -960,6 +1011,7 @@ class NicoVideoPlayService : Service() {
             isActive = true // これつけないとAlways On Displayで表示されない
             // 常に再生状態にしておく。これでAODで表示できる
             setPlaybackState(PlaybackStateCompat.Builder().setState(PlaybackStateCompat.STATE_PLAYING, 0L, 1F).build())
+            isMediaSessionActive = true
         }
     }
 
@@ -1033,17 +1085,22 @@ class NicoVideoPlayService : Service() {
             }
         }
         registerReceiver(broadcastReceiver, intentFilter)
+        isBroadcastReceiverRegistered = true
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        unregisterReceiver(broadcastReceiver)
-        if (::mediaSessionCompat.isInitialized) {
+        if (isBroadcastReceiverRegistered) {
+            unregisterReceiver(broadcastReceiver)
+            isBroadcastReceiverRegistered = false
+        }
+        if (isMediaSessionActive) {
             mediaSessionCompat.apply {
                 isActive = false
                 setPlaybackState(PlaybackStateCompat.Builder().setState(PlaybackStateCompat.STATE_NONE, 0L, 1F).build())
                 release()
             }
+            isMediaSessionActive = false
         }
         if (::exoPlayer.isInitialized) {
             exoPlayer.release()

--- a/app/src/main/java/com/kusamaru/standroid/service/NicoVideoPlayService.kt
+++ b/app/src/main/java/com/kusamaru/standroid/service/NicoVideoPlayService.kt
@@ -56,6 +56,21 @@ import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.concurrent.timerTask
 
+data class NicoVideoPlayServiceHandoffState(
+    val videoId: String,
+    val isCache: Boolean,
+    val positionMs: Long,
+    val playlist: ArrayList<NicoVideoData>?
+)
+
+object NicoVideoPlayServiceHandoff {
+    var state: NicoVideoPlayServiceHandoffState? = null
+
+    fun clear() {
+        state = null
+    }
+}
+
 /**
  * ニコ生をポップアップ、バックグラウンドで再生するやつ。
  * FragmentからServiceに移動させる
@@ -242,6 +257,7 @@ class NicoVideoPlayService : Service() {
         currentVideoCommentList.clear()
         drewedList.clear()
         nicoVideoHTML.destroy()
+        NicoVideoPlayServiceHandoff.clear()
     }
 
     /** ExoPlayerを用意する */
@@ -622,6 +638,10 @@ class NicoVideoPlayService : Service() {
         exoPlayer.seekTo(seekMs)
         // 自動再生
         exoPlayer.playWhenReady = true
+        updateBackgroundHandoffState(seekMs)
+        if (!isPopupPlay()) {
+            startBackgroundHandoffTimer()
+        }
         // MediaSession。通知もう一階出せばなんか表示されるようになった。Androidむずかちい
         showNotification(currentVideoTitle)
         initMediaSession()
@@ -938,8 +958,31 @@ class NicoVideoPlayService : Service() {
                 viewBinding?.overlayVideoControlInclude?.playerControlSeek?.progress = (exoPlayer.currentPosition / 1000L).toInt()
                 val formattedTime = DateUtils.formatElapsedTime(exoPlayer.currentPosition / 1000L)
                 viewBinding?.overlayVideoControlInclude?.playerControlCurrent?.text = formattedTime
+                updateBackgroundHandoffState(exoPlayer.currentPosition)
             }
         }
+    }
+
+    private fun startBackgroundHandoffTimer() {
+        seekTimer.cancel()
+        seekTimer = Timer()
+        seekTimer.schedule(timerTask {
+            Handler(Looper.getMainLooper()).post {
+                if (::exoPlayer.isInitialized && exoPlayer.isPlaying) {
+                    updateBackgroundHandoffState(exoPlayer.currentPosition)
+                }
+            }
+        }, 100, 1000)
+    }
+
+    private fun updateBackgroundHandoffState(positionMs: Long = if (::exoPlayer.isInitialized) exoPlayer.currentPosition else seekMs) {
+        if (playMode != "background" || currentVideoId.isEmpty()) return
+        NicoVideoPlayServiceHandoff.state = NicoVideoPlayServiceHandoffState(
+            videoId = currentVideoId,
+            isCache = isCurrentVideoCache,
+            positionMs = positionMs,
+            playlist = if (playlist.isEmpty()) null else ArrayList(playlist)
+        )
     }
 
     private fun getParams(width: Int): WindowManager.LayoutParams {
@@ -1110,6 +1153,7 @@ class NicoVideoPlayService : Service() {
         }
         seekTimer.cancel()
         nicoVideoHTML.destroy()
+        NicoVideoPlayServiceHandoff.clear()
     }
 
     /**


### PR DESCRIPTION
## Summary
- Stop the in-app NicoVideo player before handing playback to popup/background service on app leave.
- Make NicoVideoPlayService restart-safe by cleaning up previous player/session/overlay/receiver/timer state before accepting a new playback intent.
- Restore background playback back into the video Fragment when the app resumes, while leaving popup playback behavior unchanged.
- Bump versionName to 15.7.5 for release.

## Root cause
Background/popup playback started a separate service-side ExoPlayer while the Fragment-side player could remain active, especially when the setting to not pause on app switching was enabled. The service could also be restarted without fully releasing the previous player state.

Closes #37